### PR TITLE
Support for centos platforms as well

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -14,5 +14,29 @@ module NginxCookbook
         'nginx'
       end
     end
+
+    def setup_repository
+      case node.platform
+      when 'centos', 'rhel'
+
+        file '/etc/yum.repos.d/nginx.repo' do
+          owner 'root'
+          group 'root'
+          mode 0644
+          action :create
+        end
+
+        bash 'add nginx repo source' do
+          code <<-EOH
+            echo '[nginx]' | sudo tee /etc/yum.repos.d/nginx.repo
+            echo 'name=nginx repo' | sudo tee -a /etc/yum.repos.d/nginx.repo
+            echo 'baseurl=http://nginx.org/packages/#{node.platform}/$releasever/$basearch/' | sudo tee -a /etc/yum.repos.d/nginx.repo
+            echo 'gpgcheck=0' | sudo tee -a /etc/yum.repos.d/nginx.repo
+            echo 'enabled=1' | sudo tee -a /etc/yum.repos.d/nginx.repo
+          EOH
+          action :run
+        end
+      end
+    end
   end
 end

--- a/libraries/nginx_service.rb
+++ b/libraries/nginx_service.rb
@@ -73,6 +73,9 @@ class Chef::Provider::NginxService < Chef::Provider
   # Setup intial service files for nginx
   def action_enable
     notifying_block do
+
+      setup_repository
+
       # Install Packages
       package new_resource.pkg do
         package_name new_resource.pkg

--- a/libraries/nginx_service.rb
+++ b/libraries/nginx_service.rb
@@ -94,6 +94,7 @@ class Chef::Provider::NginxService < Chef::Provider
       directory '/run/nginx' do
         owner platform_user
         group platform_user
+        recursive true
         mode 0755
         action :create
       end

--- a/libraries/nginx_service.rb
+++ b/libraries/nginx_service.rb
@@ -73,7 +73,6 @@ class Chef::Provider::NginxService < Chef::Provider
   # Setup intial service files for nginx
   def action_enable
     notifying_block do
-
       setup_repository
 
       # Install Packages

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email 'acaiafa1@bloomberg.net'
 description 'Installs/Configures nginx'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.2'
 name 'nginx'
 
 depends 'poise', '~> 2.2'


### PR DESCRIPTION
Made a few changes which adds support for the centos platform.
The nginx package was not able to be installed on these platforms due to a missing repository source. Made that change. The `/run/` directory does not exist on these platforms so recursively create it when setting up the run command for nginx.
